### PR TITLE
Allow disabling status page refresh

### DIFF
--- a/src/main/java/ca/on/oicr/gsi/status/StatusPage.java
+++ b/src/main/java/ca/on/oicr/gsi/status/StatusPage.java
@@ -18,7 +18,11 @@ public abstract class StatusPage extends BasePage {
   private static final Instant START_TIME = Instant.now();
 
   public StatusPage(ServerConfig server) {
-    super(server, true);
+    this(server, true);
+  }
+
+  public StatusPage(ServerConfig server, boolean autorefresh) {
+    super(server, autorefresh);
   }
 
   @Override


### PR DESCRIPTION
The refresh is more annoying than helpful for Shesmu that has a long status page.