### PR TITLE
Add Shesmu caching to server-utils

### DIFF
--- a/src/main/java/ca/on/oicr/gsi/cache/BaseRecord.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/BaseRecord.java
@@ -1,0 +1,88 @@
+package ca.on.oicr.gsi.cache;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Takes a stream of items and stores them. When updated, it discards the existing items and
+ * replaces them all
+ */
+public abstract class BaseRecord<R, S> implements Record<R> {
+  private Instant fetchTime = Instant.EPOCH;
+  private boolean initialState = true;
+  private final Owner owner;
+  private boolean regenerating;
+  private S value;
+
+  public BaseRecord(Owner owner, S initialState) {
+    this.owner = owner;
+    this.value = initialState;
+  }
+
+  @Override
+  public int collectionSize() {
+    return collectionSize(value);
+  }
+
+  protected abstract int collectionSize(S state);
+
+  @Override
+  public final void invalidate() {
+    fetchTime = Instant.EPOCH;
+  }
+
+  @Override
+  public final Instant lastUpdate() {
+    return fetchTime;
+  }
+
+  @Override
+  public synchronized R readStale() {
+    if (initialState) {
+      throw new InitialCachePopulationException(owner.name());
+    }
+    return unpack(value);
+  }
+
+  @Override
+  public final R refresh() {
+    final boolean doRefresh;
+    boolean shouldThrow;
+    synchronized (this) {
+      final Instant now = Instant.now();
+      doRefresh = Duration.between(fetchTime, now).toMinutes() > owner.ttl() && !regenerating;
+      shouldThrow = initialState;
+      if (doRefresh) {
+        regenerating = true;
+      }
+    }
+    if (doRefresh) {
+      try (AutoCloseable timer = refreshLatency.start(owner.name())) {
+        S result = update(value, fetchTime);
+        if (result != null) {
+          synchronized (this) {
+            value = result;
+            fetchTime = Instant.now();
+            initialState = false;
+          }
+          shouldThrow = false;
+        }
+      } catch (final Exception e) {
+        e.printStackTrace();
+        staleRefreshError.labels(owner.name()).inc();
+      } finally {
+        synchronized (this) {
+          regenerating = false;
+        }
+      }
+    }
+    if (shouldThrow) {
+      throw new InitialCachePopulationException(owner.name());
+    }
+    return unpack(value);
+  }
+
+  protected abstract R unpack(S state);
+
+  protected abstract S update(S oldstate, Instant fetchTime) throws Exception;
+}

--- a/src/main/java/ca/on/oicr/gsi/cache/InitialCachePopulationException.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/InitialCachePopulationException.java
@@ -1,0 +1,7 @@
+package ca.on.oicr.gsi.cache;
+
+public class InitialCachePopulationException extends RuntimeException {
+  public InitialCachePopulationException(String cache) {
+    super(cache);
+  }
+}

--- a/src/main/java/ca/on/oicr/gsi/cache/InvalidatableRecord.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/InvalidatableRecord.java
@@ -1,0 +1,84 @@
+package ca.on.oicr.gsi.cache;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/** Caches a record until it self-identifies as stale */
+public class InvalidatableRecord<V> implements Record<Optional<V>> {
+  /**
+   * Build a new cache record type that checks when a record is valid and does a clean up when the
+   * item is being replace
+   *
+   * @param isValid the predicate to check if the cached value is still valid
+   * @param destructor the clean up procedure
+   */
+  public static <V> BiFunction<Owner, Updater<Optional<V>>, Record<Optional<V>>> checking(
+      Predicate<? super V> isValid, Consumer<? super V> destructor) {
+    return (owner, fetcher) -> new InvalidatableRecord<V>(owner, fetcher, isValid, destructor);
+  }
+
+  private final Consumer<? super V> destructor;
+  private final Updater<Optional<V>> fetcher;
+  private boolean initialState = true;
+  private final Predicate<? super V> isValid;
+  private Instant lastUpdated = Instant.EPOCH;
+  private final Owner owner;
+  private Optional<V> value = Optional.empty();
+
+  public InvalidatableRecord(
+      Owner owner,
+      Updater<Optional<V>> fetcher,
+      Predicate<? super V> isValid,
+      Consumer<? super V> destructor) {
+    super();
+    this.owner = owner;
+    this.fetcher = fetcher;
+    this.isValid = isValid;
+    this.destructor = destructor;
+  }
+
+  @Override
+  public int collectionSize() {
+    return value.isPresent() ? 1 : 0;
+  }
+
+  @Override
+  public void invalidate() {
+    value.ifPresent(destructor);
+    value = Optional.empty();
+  }
+
+  @Override
+  public Instant lastUpdate() {
+    return lastUpdated;
+  }
+
+  @Override
+  public synchronized Optional<V> readStale() {
+    return value;
+  }
+
+  @Override
+  public synchronized Optional<V> refresh() {
+    value = value.filter(isValid);
+    if (value.isPresent()) {
+      return value;
+    }
+    try (AutoCloseable timer = refreshLatency.start(owner.name())) {
+      value = fetcher.update(lastUpdated);
+      if (value.isPresent()) {
+        lastUpdated = Instant.now();
+        initialState = false;
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    if (initialState) {
+      throw new InitialCachePopulationException(owner.name());
+    }
+    return value;
+  }
+}

--- a/src/main/java/ca/on/oicr/gsi/cache/KeyValueCache.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/KeyValueCache.java
@@ -1,0 +1,133 @@
+package ca.on.oicr.gsi.cache;
+
+import io.prometheus.client.Gauge;
+import java.lang.ref.SoftReference;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+/**
+ * Store data that must be generated/fetched remotely and cache the results for a set period of
+ * time.
+ *
+ * @param <K> the keys to use to lookup data in the cache
+ * @param <V> the cached values
+ */
+public abstract class KeyValueCache<K, V> implements Owner, Iterable<Map.Entry<K, Record<V>>> {
+  public static Stream<? extends KeyValueCache<?, ?>> caches() {
+    return CACHES.values().stream().map(SoftReference::get).filter(Objects::nonNull);
+  }
+
+  private static final Map<String, SoftReference<KeyValueCache<?, ?>>> CACHES =
+      new ConcurrentHashMap<>();
+  private static final Gauge count =
+      Gauge.build("gsi_cache_kv_item_count", "Number of items in a cache.")
+          .labelNames("name")
+          .register();
+
+  private static final Gauge innerCount =
+      Gauge.build("gsi_cache_kv_max_inner_count", "The largest collection stored in a cache.")
+          .labelNames("name")
+          .register();
+  private static final Gauge ttlValue =
+      Gauge.build("gsi_cache_kv_ttl", "The time-to-live of a cache, in minutes.")
+          .labelNames("name")
+          .register();
+  private long maxCount = 0;
+
+  private final String name;
+
+  private final BiFunction<Owner, Updater<V>, Record<V>> recordCtor;
+  private final Map<K, Record<V>> records = new ConcurrentHashMap<>();
+  private int ttl;
+
+  /**
+   * Create a new cache
+   *
+   * @param name the name, as presented to Prometheus
+   * @param ttl the number of minutes an item will remain in cache
+   */
+  public KeyValueCache(String name, int ttl, BiFunction<Owner, Updater<V>, Record<V>> recordCtor) {
+    super();
+    this.name = name;
+    this.ttl = ttl;
+    this.recordCtor = recordCtor;
+    ttlValue.labels(name).set(ttl);
+    CACHES.put(name, new SoftReference<>(this));
+  }
+
+  /**
+   * Fetch an item from the remote service (or generate it)
+   *
+   * @param key the item to be requested
+   * @param lastUpdated the last time the item was successfully fetched
+   * @return the cached value
+   * @throws Exception if an error occurs, the previous value will be retained
+   */
+  protected abstract V fetch(K key, Instant lastUpdated) throws Exception;
+
+  /**
+   * Get an item from cache
+   *
+   * @param key the key to use
+   * @return the value, if it was possible to fetch; the value may be stale if the remote end-point
+   *     is in an error state
+   */
+  public final V get(K key) {
+    final Record<V> record =
+        records.computeIfAbsent(
+            key, k -> recordCtor.apply(this, lastModified -> fetch(k, lastModified)));
+    maxCount = Math.max(maxCount, record.collectionSize());
+    innerCount.labels(name).set(maxCount);
+    count.labels(name).set(records.size());
+    return record.refresh();
+  }
+  /**
+   * Get an item from cache without updating it
+   *
+   * @param key the key to use
+   * @return the last value that was fetched
+   */
+  public final V getStale(K key) {
+    final Record<V> record =
+        records.computeIfAbsent(
+            key, k -> recordCtor.apply(this, lastModified -> fetch(k, lastModified)));
+    return record.readStale();
+  }
+
+  public final void invalidate(K key) {
+    final Record<V> record = records.get(key);
+    if (record != null) {
+      record.invalidate();
+    }
+  }
+
+  public void invalidateAll() {
+    maxCount = 0;
+    innerCount.labels(name).set(maxCount);
+    records.values().forEach(Record::invalidate);
+  }
+
+  public final Iterator<Map.Entry<K, Record<V>>> iterator() {
+    return records.entrySet().iterator();
+  }
+
+  @Override
+  public final String name() {
+    return name;
+  }
+
+  @Override
+  public final long ttl() {
+    return ttl;
+  }
+
+  public final void ttl(int ttl) {
+    this.ttl = ttl;
+    ttlValue.labels(name).set(ttl);
+  }
+}

--- a/src/main/java/ca/on/oicr/gsi/cache/MergingRecord.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/MergingRecord.java
@@ -1,0 +1,59 @@
+package ca.on.oicr.gsi.cache;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Stores an incrementally appending list of items. When new items are provided, old ones with
+ * matching IDs are replaced
+ *
+ * @param <V> the type of the items
+ * @param <I> the type of the ids
+ */
+public final class MergingRecord<V, I> extends BaseRecord<Stream<V>, List<V>> {
+
+  /** Merge records by the supplied id */
+  public static <V, I> BiFunction<Owner, Updater<Stream<V>>, Record<Stream<V>>> by(
+      Function<V, I> getId) {
+    return (owner, fetcher) -> new MergingRecord<>(owner, fetcher, getId);
+  }
+
+  private final Updater<Stream<V>> fetcher;
+  private final Function<V, I> getId;
+
+  public MergingRecord(Owner owner, Updater<Stream<V>> fetcher, Function<V, I> getId) {
+    super(owner, Collections.emptyList());
+    this.fetcher = fetcher;
+    this.getId = getId;
+  }
+
+  @Override
+  protected int collectionSize(List<V> state) {
+    return state.size();
+  }
+
+  @Override
+  protected Stream<V> unpack(List<V> state) {
+    return state.stream();
+  }
+
+  @Override
+  protected List<V> update(List<V> oldstate, Instant fetchTime) throws Exception {
+    final Stream<V> stream = fetcher.update(fetchTime);
+    if (stream == null) {
+      return null;
+    }
+    final List<V> buffer = stream.collect(Collectors.toList());
+    stream.close();
+    final Set<I> newIds = buffer.stream().map(getId).collect(Collectors.toSet());
+    return Stream.concat(
+            oldstate.stream().filter(item -> !newIds.contains(getId.apply(item))), buffer.stream())
+        .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/ca/on/oicr/gsi/cache/Owner.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/Owner.java
@@ -1,0 +1,10 @@
+package ca.on.oicr.gsi.cache;
+
+/** Interface for caches so that records can communicate with their containers */
+public interface Owner {
+  /** The name of the cache for use in monitoring */
+  String name();
+
+  /** The time-to-live for a record in cache */
+  long ttl();
+}

--- a/src/main/java/ca/on/oicr/gsi/cache/Record.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/Record.java
@@ -1,0 +1,39 @@
+package ca.on.oicr.gsi.cache;
+
+import ca.on.oicr.gsi.prometheus.LatencyHistogram;
+import io.prometheus.client.Counter;
+import java.time.Instant;
+
+/**
+ * A record stored in a cache of some kind
+ *
+ * @param <V> the type of cached item
+ */
+public interface Record<V> {
+  public static final LatencyHistogram refreshLatency =
+      new LatencyHistogram(
+          "gsi_cache_refresh_latency",
+          "Attempted to refresh a value stored in cache, but the refresh failed.",
+          "name");
+  public static final Counter staleRefreshError =
+      Counter.build(
+              "gsi_cache_refresh_error",
+              "Attempted to refresh a value stored in cache, but the refresh failed.")
+          .labelNames("name")
+          .register();
+
+  /** The number of items stored in this cache record F */
+  int collectionSize();
+
+  /** Force the cached item to be reloaded on the next use. */
+  void invalidate();
+
+  /** Get the last time the item was updated */
+  Instant lastUpdate();
+
+  /** Get the current item value, but do not fetch */
+  V readStale();
+
+  /** Get the current item value, fetching if necessary */
+  V refresh();
+}

--- a/src/main/java/ca/on/oicr/gsi/cache/ReplacingRecord.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/ReplacingRecord.java
@@ -1,0 +1,42 @@
+package ca.on.oicr.gsi.cache;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Takes a stream of items and stores them. When updated, it discards the existing items and
+ * replaces them all
+ */
+public final class ReplacingRecord<V> extends BaseRecord<Stream<V>, List<V>> {
+  private final Updater<Stream<V>> fetcher;
+
+  public ReplacingRecord(Owner owner, Updater<Stream<V>> fetcher) {
+    super(owner, Collections.emptyList());
+    this.fetcher = fetcher;
+  }
+
+  @Override
+  protected int collectionSize(List<V> state) {
+    return state.size();
+  }
+
+  @Override
+  protected Stream<V> unpack(List<V> state) {
+    return state.stream();
+  }
+
+  @Override
+  protected List<V> update(List<V> oldstate, Instant fetchTime) throws Exception {
+    final Stream<V> stream = fetcher.update(fetchTime);
+    if (stream != null) {
+      final List<V> result = stream.collect(Collectors.toList());
+      stream.close();
+      return result;
+    } else {
+      return null;
+    }
+  }
+}

--- a/src/main/java/ca/on/oicr/gsi/cache/SimpleRecord.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/SimpleRecord.java
@@ -1,0 +1,35 @@
+package ca.on.oicr.gsi.cache;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Hold on to a single value
+ *
+ * <p>If the value could not be fetched, the previous value will be used instead.
+ */
+public final class SimpleRecord<V> extends BaseRecord<Optional<V>, Optional<V>> {
+
+  private final Updater<Optional<V>> fetcher;
+
+  public SimpleRecord(Owner owner, Updater<Optional<V>> fetcher) {
+    super(owner, Optional.empty());
+    this.fetcher = fetcher;
+  }
+
+  @Override
+  protected int collectionSize(Optional<V> value) {
+    return value.isPresent() ? 1 : 0;
+  }
+
+  @Override
+  protected Optional<V> unpack(Optional<V> state) {
+    return state;
+  }
+
+  @Override
+  protected Optional<V> update(Optional<V> oldstate, Instant fetchTime) throws Exception {
+    final Optional<V> buffer = fetcher.update(fetchTime);
+    return buffer.isPresent() ? buffer : null;
+  }
+}

--- a/src/main/java/ca/on/oicr/gsi/cache/Updater.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/Updater.java
@@ -1,0 +1,13 @@
+package ca.on.oicr.gsi.cache;
+
+import java.time.Instant;
+
+/** Service to update a record in cache */
+public interface Updater<V> {
+  /**
+   * Perform the update
+   *
+   * @param lastModifed the last time the value was successfully pulled from cache
+   */
+  V update(Instant lastModifed) throws Exception;
+}

--- a/src/main/java/ca/on/oicr/gsi/cache/ValueCache.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/ValueCache.java
@@ -1,0 +1,108 @@
+package ca.on.oicr.gsi.cache;
+
+import io.prometheus.client.Gauge;
+import java.lang.ref.SoftReference;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+
+/**
+ * Store data that must be generated/fetched remotely and cache the results for a set period of
+ * time.
+ *
+ * @param <V> the cached value
+ */
+public abstract class ValueCache<V> implements Owner {
+
+  public static Stream<? extends ValueCache<?>> caches() {
+    return CACHES.values().stream().map(SoftReference::get).filter(Objects::nonNull);
+  }
+
+  private static final Map<String, SoftReference<ValueCache<?>>> CACHES = new ConcurrentHashMap<>();
+  private static final Gauge innerCount =
+      Gauge.build("gsi_cache_v_max_inner_count", "The largest collection stored in a cache.")
+          .labelNames("name")
+          .register();
+  private static final Gauge ttlValue =
+      Gauge.build("gsi_cache_v_ttl", "The time-to-live of a cache, in minutes.")
+          .labelNames("name")
+          .register();
+  private final String name;
+
+  private int ttl;
+
+  private final Record<V> value;
+
+  /**
+   * Create a new cache
+   *
+   * @param name the name, as presented to Prometheus
+   * @param ttl the number of minutes an item will remain in cache
+   */
+  public ValueCache(String name, int ttl, BiFunction<Owner, Updater<V>, Record<V>> recordCtor) {
+    super();
+    this.name = name;
+    this.ttl = ttl;
+    this.value = recordCtor.apply(this, this::fetch);
+    ttlValue.labels(name).set(ttl);
+    CACHES.put(name, new SoftReference<>(this));
+  }
+
+  public int collectionSize() {
+    return value.collectionSize();
+  }
+
+  /**
+   * Fetch an item from the remote service (or generate it)
+   *
+   * @param lastUpdated the last time this item was successfully updated
+   * @return the cached value
+   */
+  protected abstract V fetch(Instant lastUpdated) throws Exception;
+
+  /**
+   * Get an item from cache
+   *
+   * @return the value, if it was possible to fetch; the value may be stale if the remote end-point
+   *     is in an error state
+   */
+  public V get() {
+    final V item = value.refresh();
+    innerCount.labels(name).set(value.collectionSize());
+    return item;
+  }
+  /**
+   * Get an item from cache, but do not update it
+   *
+   * @return the last value put in the cache
+   */
+  public V getStale() {
+    return value.readStale();
+  }
+
+  public void invalidate() {
+    value.invalidate();
+  }
+
+  public Instant lastUpdated() {
+    return value.lastUpdate();
+  }
+
+  @Override
+  public final String name() {
+    return name;
+  }
+
+  @Override
+  public final long ttl() {
+    return ttl;
+  }
+
+  public final void ttl(int ttl) {
+    this.ttl = ttl;
+    ttlValue.labels(name).set(ttl);
+  }
+}

--- a/src/main/java/ca/on/oicr/gsi/cache/package-info.java
+++ b/src/main/java/ca/on/oicr/gsi/cache/package-info.java
@@ -1,0 +1,2 @@
+/** Utilities for creating caches of expiring values that can refill on access */
+package ca.on.oicr.gsi.cache;


### PR DESCRIPTION
This is for future use by Pinery. No real changes from the Shesmu version other than changing the Prometheus variables to be `gsi_` instead of `shesmu_`.