### PR TITLE
Force output stream to be UTF-8 for pages

### DIFF
--- a/src/main/java/ca/on/oicr/gsi/status/BasePage.java
+++ b/src/main/java/ca/on/oicr/gsi/status/BasePage.java
@@ -56,7 +56,7 @@ public abstract class BasePage {
   public final void renderPage(OutputStream output) {
     final XMLOutputFactory outputFactory = XMLOutputFactory.newFactory();
     try {
-      final XMLStreamWriter writer = outputFactory.createXMLStreamWriter(output);
+      final XMLStreamWriter writer = outputFactory.createXMLStreamWriter(output, "UTF-8");
       writer.writeStartDocument("utf-8", "1.0");
       writer.writeStartElement("html");
 


### PR DESCRIPTION
The stream is by default opened in the platform's local encoding, which will
generate an error if the platform is not UTF-8. In Docker containers, it is
often set to ASCII.