### PR TITLE
Add Jigsaw module support and upgrade Prometheus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
     	<groupId>io.prometheus</groupId>
     	<artifactId>simpleclient</artifactId>
-    	<version>0.0.26</version>
+    	<version>0.9.0</version>
     </dependency>
   </dependencies>
   <build>
@@ -48,6 +48,18 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>ca.oicr.gsi.serverutils</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This adds a JAR directive that allows this code to be referenced from Java 9's
module system (Jigsaw) without updating the built to Java 9. It also upgrades
Prometheus to a version that is compatible with the Java 9 module system.